### PR TITLE
Updated the file browse function to use existing paths or project root

### DIFF
--- a/script_generator/gui/utils/widgets.py
+++ b/script_generator/gui/utils/widgets.py
@@ -172,7 +172,7 @@ class Widgets:
         return button
 
     @staticmethod
-    def file_selection(parent, label_text, button_text, file_selector_title, file_types, state, attr, command=None, row=0, label_width_px=150, button_width_px=100, tooltip_text=None, select_folder=False, **grid_kwargs):
+    def file_selection(parent, label_text, button_text, file_selector_title, file_types, state, attr, command=None, row=0, label_width_px=150, button_width_px=100, tooltip_text=None, select_folder=False, initial_dir=None, **grid_kwargs):
         grid_kwargs.setdefault("pady", 5)
         grid_kwargs.setdefault("padx", 5)
         grid_kwargs.setdefault("sticky","nsew")
@@ -208,10 +208,29 @@ class Widgets:
         button_container.grid(row=0, column=2, sticky="e", padx=(2, 5))
         button_container.grid_propagate(False)  # Prevent resizing
         def browse():
+            current_path = getattr(state, attr, "")
+            initial_directory = initial_dir
+
+            if initial_directory is None and current_path and os.path.exists(current_path):
+                initial_directory = os.path.dirname(current_path)
+
+            if initial_directory is None or not os.path.exists(initial_directory):
+                initial_directory = os.path.abspath(os.path.dirname(__file__))
+                # I don't know a better way to do this, I've set it to go back to the project root if know previous path exists.
+                for _ in range(3):
+                    initial_directory = os.path.dirname(initial_directory)
+
             if select_folder:
-                selected_path = filedialog.askdirectory(title=file_selector_title)
+                selected_path = filedialog.askdirectory(
+                    title=file_selector_title,
+                    initialdir=initial_directory
+                )
             else:
-                selected_path = filedialog.askopenfilename(title=file_selector_title, filetypes=file_types)
+                selected_path = filedialog.askopenfilename(
+                    title=file_selector_title,
+                    filetypes=file_types,
+                    initialdir=initial_directory
+                )
             if selected_path:
                 file_path.set(selected_path)
                 setattr(state, attr, selected_path)

--- a/script_generator/gui/views/funscript_generator.py
+++ b/script_generator/gui/views/funscript_generator.py
@@ -16,6 +16,7 @@ from script_generator.gui.views.popups.create_debug_video import render_debug_vi
 from script_generator.gui.views.popups.edit_video_info import render_video_edit_popup
 from script_generator.object_detection.util.data import get_raw_yolo_file_info
 from script_generator.state.app_state import AppState
+import os
 
 
 class FunscriptGeneratorPage(tk.Frame):
@@ -55,7 +56,8 @@ class FunscriptGeneratorPage(tk.Frame):
             state=state,
             tooltip_text="The video to generate a funscript for. For proper detection of fisheye keep the suffix like _FISHEYE190, _MKX200, etc. in the filename\n\nIn the future we'll add the option to override this in the UI.",
             command=lambda val: update_video_path(),
-            pady=(0, 0)
+            pady=(0, 0),
+            initial_dir=os.path.dirname(str(state.video_path)) if state.video_path else None
         )
 
         video_info_container = Widgets.frame(video_selection, row=1, padx=(0, 0), pady=(0, 5), min_height=35)
@@ -244,7 +246,8 @@ class FunscriptGeneratorPage(tk.Frame):
             file_types=[("Funscript Files", "*.funscript"), ("All Files", "*.*")],
             tooltip_text="If provided the reference script will be compared in the\nfunscript report that is generated on completion and be shown\nin the live display funscript overlay when enabled.",
             state=state,
-            row=0
+            row=0,
+            initial_dir=os.path.dirname(str(state.reference_script)) if state.reference_script else None
         )
         debug_video_section = Widgets.frame(debugging, title="Share debug files", row=2)
         gen_video_btn = Widgets.button(

--- a/script_generator/gui/views/settings.py
+++ b/script_generator/gui/views/settings.py
@@ -3,6 +3,7 @@ import tkinter as tk
 from script_generator.debug.logger import set_log_level
 from script_generator.gui.utils.widgets import Widgets
 from script_generator.state.app_state import AppState
+import os
 
 
 class SettingsPage(tk.Frame):
@@ -25,7 +26,6 @@ class SettingsPage(tk.Frame):
             command=lambda val: c.save(),
             row=0
         )
-
         Widgets.file_selection(
             attr="funscript_output_dir",
             parent=general_settings,
@@ -37,7 +37,8 @@ class SettingsPage(tk.Frame):
             tooltip_text="Set an optional output folder where the final funscript will be copied to.",
             command=lambda val: c.save(),
             select_folder=True,
-            row=1
+            row=1,
+            initial_dir=self.state.funscript_output_dir if self.state.funscript_output_dir and os.path.exists(self.state.funscript_output_dir) else None
         )
 
         Widgets.checkbox(
@@ -63,7 +64,8 @@ class SettingsPage(tk.Frame):
             state=self.state,
             tooltip_text="Path to the YOLO model file.",
             command=lambda val: c.save(),
-            row=0
+            row=0,
+            initial_dir=os.path.dirname(self.state.yolo_model_path) if self.state.yolo_model_path else None
         )
 
         ffmpeg_settings = Widgets.frame(self, title="FFmpeg", main_section=True, row=2)
@@ -78,7 +80,8 @@ class SettingsPage(tk.Frame):
             state=self.state,
             tooltip_text="Path to the FFmpeg executable.",
             command=lambda val: c.save(),
-            row=0
+            row=0,
+            initial_dir=os.path.dirname(self.state.ffmpeg_path) if self.state.ffmpeg_path else None
         )
 
         Widgets.file_selection(
@@ -91,7 +94,8 @@ class SettingsPage(tk.Frame):
             state=self.state,
             tooltip_text="Path to the FFprobe executable.",
             command=lambda val: c.save(),
-            row=1
+            row=1,
+            initial_dir=os.path.dirname(self.state.ffprobe_path) if self.state.ffprobe_path else None
         )
 
         Widgets.dropdown(


### PR DESCRIPTION
**The issue**

The browse buttons would default to the last folder accessed by another browse button. So if you clicked browse for a model then browsed for a video you would start in the model path. Then if you went to set a funscript output path it would start in the video path.

**The changes**
- If no path exists use the project root

- If a path exists go to that path. For example, if you want to select another video you start in the folder for the previous video

- All browse buttons operate independently of each other


I'm not 100% happy with my go to the project root solution. Going up 3 folders from the widgets.py is pretty hacky.