### PR TITLE
fix: proper locks for s1 monitor

### DIFF
--- a/detection/cd/stage_1_cd.py
+++ b/detection/cd/stage_1_cd.py
@@ -29,18 +29,21 @@ class Stage1QueueMonitor:
             queue.put(item)
 
     def frame_queue_get(self, queue, block=True, timeout=None):
-        item = queue.get(block=block, timeout=timeout)
-        with self.frame_queue_gets.get_lock(): self.frame_queue_gets.value += 1
-        return item
+        with self.frame_queue_gets.get_lock():
+            item = queue.get(block=block, timeout=timeout)
+            self.frame_queue_gets.value += 1
+            return item
 
     def result_queue_put(self, queue, item):
-        with self.result_queue_puts.get_lock(): self.result_queue_puts.value += 1
-        queue.put(item)
+        with self.result_queue_puts.get_lock():
+            self.result_queue_puts.value += 1
+            queue.put(item)
 
     def result_queue_get(self, queue, block=True, timeout=None):
-        item = queue.get(block=block, timeout=timeout)
-        with self.result_queue_gets.get_lock(): self.result_queue_gets.value += 1
-        return item
+        with self.result_queue_gets.get_lock():
+            item = queue.get(block=block, timeout=timeout)
+            self.result_queue_gets.value += 1
+            return item
 
     def get_frame_queue_size(self):
         with self.frame_queue_puts.get_lock(), self.frame_queue_gets.get_lock():


### PR DESCRIPTION
Updates all of the queue monitor operations to be threadsafe for the contents of the methods. I still have concerns that the locking might be insufficient for surrounding operations. These should probably allow passing a closure so they can capture any other logic that needs to occur within the lock scope. For now, this should be a good improvement.