### PR TITLE
FIX: Added audio waveform initialization

### DIFF
--- a/application/logic/app_logic.py
+++ b/application/logic/app_logic.py
@@ -163,6 +163,9 @@ class ApplicationLogic:
         self.batch_overwrite_mode: int = 0  # 0 for Process All, 1 for Skip Existing
         self.batch_generate_roll_file: bool = True
 
+        # --- Audio waveform data ---
+        self.audio_waveform_data = None
+
         # --- Final Setup Steps ---
         self._apply_loaded_settings()
         self.funscript_processor._ensure_undo_managers_linked()


### PR DESCRIPTION
**--- Edge case crash fix ---**

How to trigger bug:
- Before adding this fix, delete imgui.ini and settings.json.
This will set the app back to original settings as if you run the app for the first time.
- Run the FunGen app, do _not_ load any media (video)!
- Make a change to the UI.
ie change the size of the 'script Gauge' window.
- Wait for autosave to trigger.
- App crashes.

Reason:
- self.audio_waveform_data has not been initiated, because no video has been loaded.
- The autosave will call the value to try and save it's status.

Initializing the value to 'None' fixes the empty value issue upon saving.