### PR TITLE
FIX: refactor GeneratedFileManagerWindow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,10 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+.gitignore
+*.funscript
+__pycache__
+*.pyc
+*.md
+*.ini
+settings.json

--- a/core.requirements.txt
+++ b/core.requirements.txt
@@ -11,5 +11,5 @@ matplotlib~=3.10.0
 simplification~=0.7.13
 msgpack~=1.1.0
 pillow~=11.1.0
-orjson~=3.10.
+orjson~=3.10.15
 send2trash~=1.8.3

--- a/core.requirements.txt
+++ b/core.requirements.txt
@@ -11,4 +11,5 @@ matplotlib~=3.10.0
 simplification~=0.7.13
 msgpack~=1.1.0
 pillow~=11.1.0
-orjson~=3.10.15
+orjson~=3.10.
+send2trash~=1.8.3


### PR DESCRIPTION
- Refactored the "Delete All" popup logic. Button popup confirmation modal was being blocked.
- Introduced a checkbox to the GeneratedFileManagerWindow allowing users to choose whether to delete .funscript files when clearing generated files.
- Added deletion logic to prevent .funsscript deleteion when the folder is being deleted
- Funscript 'delete' buttons are disabled when 'include .funscript files' is unchecked

REF: Update file deletion logic in GeneratedFileManagerWindow

- Replaced direct file and folder deletion with send2trash for safer removal.
- Added send2trash import to the file manager window.
- Updated success and error messages to reflect the new deletion method.
- Minor formatting adjustments for consistency.