### PR TITLE
Fix/missing check after clearing timeline

### DIFF
--- a/FunGen-AI-Powered-Funscript-Generator.code-workspace
+++ b/FunGen-AI-Powered-Funscript-Generator.code-workspace
@@ -1,0 +1,8 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {}
+}

--- a/FunGen-AI-Powered-Funscript-Generator.code-workspace
+++ b/FunGen-AI-Powered-Funscript-Generator.code-workspace
@@ -1,8 +1,0 @@
-{
-	"folders": [
-		{
-			"path": "."
-		}
-	],
-	"settings": {}
-}

--- a/funscript/dual_axis_funscript.py
+++ b/funscript/dual_axis_funscript.py
@@ -90,7 +90,7 @@ class DualAxisFunscript:
                 # No timestamp change, so cache is still valid
         else:
             can_insert = True
-            if idx > 0:
+            if idx > 0 and len(actions_target_list) > 0:
                 prev_action = actions_target_list[idx - 1]
                 if timestamp_ms - prev_action["at"] < min_interval_ms:
                     can_insert = False


### PR DESCRIPTION
- Mismatching total frames after clearing script timeline with video frame count.