### PR TITLE
Add missing variable when an exception happened during stage1

### DIFF
--- a/application/logic/app_stage_processor.py
+++ b/application/logic/app_stage_processor.py
@@ -610,6 +610,8 @@ class AppStageProcessor:
         fm = self.app.file_manager
         fs_proc = self.app.funscript_processor
         stage1_success = False
+        stage2_success = False
+        stage3_success = False
         preprocessed_path_for_s3 = None  # Initialize to prevent UnboundLocalError
 
         # Always use the tracker mode from the UI state, which is the single source of truth.


### PR DESCRIPTION
```
  self.run()
File "/home/user/.local/share/uv/python/cpython-3.10.18-linux-x86_64-gnu/lib/python3.10/threading.py", line 953, in run
  self._target(*self._args, **self._kwargs)
File "/home/user/fungen-AI-Powered-Funscript-Generator/application/logic/app_stage_processor.py", line 884, in _run_full_analysis_thread_target
  if stage1_success and stage2_success and (selected_mode == TrackerMode.OFFLINE_2_STAGE or stage3_success):
UnboundLocalError: local variable 'stage2_success' referenced before assignment
```